### PR TITLE
Fix badge links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # translator-helper README
 
 [![Build Status](https://dev.azure.com/xiaodiyan/VSCode%20TranslatorHelper/_apis/build/status/yanxiaodi.vscode-translator-helper?branchName=master)](https://dev.azure.com/xiaodiyan/VSCode%20TranslatorHelper/_build/latest?definitionId=58&branchName=master)
-[![Current Version](https://vsmarketplacebadge.apphb.com/version/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
-[![Install Count](https://vsmarketplacebadge.apphb.com/installs/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
-[![Ratings](https://vsmarketplacebadge.apphb.com/rating/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
+[![Current Version](https://vsmarketplacebadges.dev/version/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
+[![Install Count](https://vsmarketplacebadges.dev/installs/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
+[![Ratings](https://vsmarketplacebadges.dev/rating/XiaodiYan.translator-helper.svg)](https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper)
 
 **translator-helper** is a VS Code Extension to simplify the translation of documents, especially for the localization of Docs.
 

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
             "description": "Azure DevOps Pipilines status"
         },
         {
-            "url": "https://vsmarketplacebadge.apphb.com/version/XiaodiYan.translator-helper.svg",
+            "url": "https://vsmarketplacebadges.dev/version/XiaodiYan.translator-helper.svg",
             "href": "https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper",
             "description": "Current Version"
         },
         {
-            "url": "https://vsmarketplacebadge.apphb.com/installs/XiaodiYan.translator-helper.svg",
+            "url": "https://vsmarketplacebadges.dev/installs/XiaodiYan.translator-helper.svg",
             "href": "https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper",
             "description": "Install Count"
         },
         {
-            "url": "https://vsmarketplacebadge.apphb.com/rating/XiaodiYan.translator-helper.svg",
+            "url": "https://vsmarketplacebadges.dev/rating/XiaodiYan.translator-helper.svg",
             "href": "https://marketplace.visualstudio.com/items?itemName=XiaodiYan.translator-helper",
             "description": "Ratings"
         }


### PR DESCRIPTION
## Problem

```sh
> vsce pack
ERROR  Badge SVGs are restricted. Please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version/XiaodiYan.translator-helper.svg
```

## Solution

https://code.visualstudio.com/api/working-with-extensions/publishing-extension?publishing-extensions#publishing-extensions